### PR TITLE
Add Panda3D ethical decision game skeleton

### DIFF
--- a/moral_ai.py
+++ b/moral_ai.py
@@ -1,0 +1,50 @@
+"""
+Machine Morality: A 3D ethical decision-making game built using Panda3D.
+
+Goal:
+Simulate an AI driving a car through a virtual city. The AI encounters moral dilemmas like choosing between two pedestrians or swerving into a wall. Each decision should log the ethical choice and trigger world state changes.
+
+Requirements:
+- Basic 3D world with ground, road, and simple car model.
+- Player controls a car using arrow keys.
+- When a dilemma zone is entered, pause movement and present 2–3 choices via on-screen text.
+- Log the player's decision and show outcome.
+- Ethical evaluation stub (can be expanded later).
+"""
+
+from direct.showbase.ShowBase import ShowBase
+from panda3d.core import TextNode, CollisionNode, CollisionSphere, CollisionHandlerEvent
+from direct.gui.OnscreenText import OnscreenText
+
+class MoralAI(ShowBase):
+    def __init__(self):
+        super().__init__()
+        self.load_environment()
+        self.setup_controls()
+        self.setup_decision_zones()
+        self.accept('collision-into-zone1', self.trigger_moral_dilemma)
+
+    def load_environment(self):
+        # Load flat city scene, ground, road, and car model
+        pass
+
+    def setup_controls(self):
+        # Allow car to move with arrow keys
+        pass
+
+    def setup_decision_zones(self):
+        # Place invisible collision spheres as ethical decision triggers
+        pass
+
+    def trigger_moral_dilemma(self, entry):
+        # Pause car movement
+        # Display ethical dilemma with options
+        # Log choice and show feedback (e.g., on-screen text)
+        pass
+
+    def evaluate_choice(self, choice):
+        # Placeholder: evaluate decision using ethical principles (e.g., utilitarian)
+        pass
+
+game = MoralAI()
+game.run()


### PR DESCRIPTION
## Summary
- add `moral_ai.py` with stub code for a 3D ethical decision-making game using Panda3D

## Testing
- `python3 -m py_compile moral_ai.py`


------
https://chatgpt.com/codex/tasks/task_e_683f9e17a5c483319fb979941f9ae4b8